### PR TITLE
Changing the version of recyclerview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.0.1'
+    compile 'com.android.support:recyclerview-v7:25.1.0'
     testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
As of using android studio 3.0 canary 1, it's suggesting to use the same library version specification as mixing version may lead to runtime crashes.Thus implementing the same.