### PR TITLE
Added permission for ACCESS_NOTIFICATION_POLICY

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,4 +31,5 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
 </manifest>


### PR DESCRIPTION
In mobiles running SDK >= 24, when clicked on "Ringer Permissions", the app's name must be shown in the "Do Not Disturb Access" intent for the Sushme app to enable Ringer Pemissions.